### PR TITLE
WIP: Support for multiple references to sign

### DIFF
--- a/lib/xml/kit/signature.rb
+++ b/lib/xml/kit/signature.rb
@@ -24,19 +24,26 @@ module Xml
 
       attr_reader :certificate
       attr_reader :digest_method
-      attr_reader :reference_id
+      attr_reader :reference_ids
       attr_reader :signature_method
 
       def initialize(
-        reference_id,
+        reference_ids,
         signature_method: :SH256,
         digest_method: :SHA256,
         certificate:
       )
         @certificate = certificate
         @digest_method = DIGEST_METHODS[digest_method]
-        @reference_id = reference_id
+        @reference_ids = Array(reference_ids)
         @signature_method = SIGNATURE_METHODS[signature_method]
+      end
+
+      def enveloped?
+        # As only one referenced passed, we assume it's enveloped (signature is child)
+        # With more references only enveloping (signature is parent) makes sense
+        # Better but more complicated: check if `reference_id` if a parent node
+        reference_ids.size == 1
       end
 
       def to_xml(xml: ::Builder::XmlMarkup.new)

--- a/lib/xml/kit/signatures.rb
+++ b/lib/xml/kit/signatures.rb
@@ -19,11 +19,11 @@ module Xml
       end
 
       # @!visibility private
-      def build(reference_id)
+      def build(reference_ids)
         return nil if key_pair.nil?
 
         ::Xml::Kit::Signature.new(
-          reference_id,
+          reference_ids,
           certificate: key_pair.certificate,
           signature_method: signature_method,
           digest_method: digest_method
@@ -65,8 +65,8 @@ module Xml
         end
 
         # @!visibility private
-        def template(reference_id)
-          Template.new(signatures.build(reference_id)).to_xml(xml: xml)
+        def template(reference_ids)
+          Template.new(signatures.build(reference_ids)).to_xml(xml: xml)
         end
       end
     end

--- a/lib/xml/kit/templatable.rb
+++ b/lib/xml/kit/templatable.rb
@@ -88,7 +88,7 @@ module Xml
       def signature_for(reference_id:, xml:)
         return unless sign?
 
-        signatures.build(reference_id).to_xml(xml: xml)
+        signatures.build([reference_id]).to_xml(xml: xml)
       end
 
       # Allows you to specify which key pair to use for generating an XML digital signature.

--- a/lib/xml/kit/templates/signature.builder
+++ b/lib/xml/kit/templates/signature.builder
@@ -4,13 +4,17 @@ xml.Signature 'xmlns' => ::Xml::Kit::Namespaces::XMLDSIG do
   xml.SignedInfo do
     xml.CanonicalizationMethod Algorithm: ::Xml::Kit::Namespaces::CANONICALIZATION
     xml.SignatureMethod Algorithm: signature_method
-    xml.Reference URI: "##{reference_id}" do
-      xml.Transforms do
-        xml.Transform Algorithm: "#{::Xml::Kit::Namespaces::XMLDSIG}enveloped-signature"
-        xml.Transform Algorithm: ::Xml::Kit::Namespaces::CANONICALIZATION
+    reference_ids.each do |reference_id|
+      xml.Reference URI: "##{reference_id}" do
+        xml.Transforms do
+          if enveloped?
+            xml.Transform Algorithm: "#{::Xml::Kit::Namespaces::XMLDSIG}enveloped-signature"
+          end
+          xml.Transform Algorithm: ::Xml::Kit::Namespaces::CANONICALIZATION
+        end
+        xml.DigestMethod Algorithm: digest_method
+        xml.DigestValue ''
       end
-      xml.DigestMethod Algorithm: digest_method
-      xml.DigestValue ''
     end
   end
   xml.SignatureValue ''


### PR DESCRIPTION
Hey, another challenge :D

I just had a quick look into signing. here I currently use https://github.com/ebeigarts/signer although I wouldn't mind using ur gem for less dependencies. But for that I'm need of signing multiple nodes all together, which support is currently missing.  
With this PR I kind of got a POC running by passing an array of reference Id + iteration and additionally removing `'http://www.w3.org/2000/09/xmldsig#enveloped-signature`. 

Final steps and test to come..
